### PR TITLE
Update supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 install:
   - python setup.py install
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyramda [![Build Status](https://travis-ci.org/jackfirth/pyramda.svg?branch=master)](https://travis-ci.org/jackfirth/pyramda) [![Coverage Status](https://coveralls.io/repos/jackfirth/pyramda/badge.svg?branch=master&service=github)](https://coveralls.io/github/jackfirth/pyramda?branch=master)
 
-Python package supporting heavy functional programming through currying and function composition. Translation of the Ramda library from javascript to python. Supports Python 2.6, 2.7, 3.2, 3.3, and 3.4.
+Python package supporting heavy functional programming through currying and function composition. Translation of the Ramda library from javascript to python. Supports Python 2.6, 2.7, 3.3, 3.4, and 3.5.
 
 ```
 pip install pyramda


### PR DESCRIPTION
Coverage.py no longer supports 3.2, and 3.5 has been out for months now