### PR TITLE
Import pipe in __init__

### DIFF
--- a/pyramda/function/__init__.py
+++ b/pyramda/function/__init__.py
@@ -3,4 +3,5 @@ from .apply import apply
 from .compose import compose
 from .curry import curry
 from .identity import identity
+from .pipe import pipe
 from .tap import tap


### PR DESCRIPTION
`pipe` did not find it's way into `__init__`.