### PR TITLE
Refactor flatten function implementation

### DIFF
--- a/pyramda/iterable/flatten.py
+++ b/pyramda/iterable/flatten.py
@@ -18,13 +18,13 @@ def flatten_until(is_leaf, xs):
     """
 
     def _flatten_until(items):
-        for item in items:
-            if isinstance(Iterable, item) and not is_leaf(item):
+        if isinstance(Iterable, items) and not is_leaf(items):
+            for item in items:
                 for i in _flatten_until(item):
                     yield i
-            else:
-                yield item
+        else:
+            yield items
 
-    return list(_flatten_until(xs)) if isinstance(Iterable, xs) and not is_leaf(xs) else xs
+    return list(_flatten_until(xs))
 
 flatten = flatten_until(isinstance(basestring))

--- a/pyramda/iterable/flatten.py
+++ b/pyramda/iterable/flatten.py
@@ -1,37 +1,30 @@
 from collections import Iterable
 from past.builtins import basestring
 
+from pyramda.isinstance import isinstance
 from pyramda.function.curry import curry
 
 
 @curry
-def flatten(xs, depth):
+def flatten_until(is_leaf, xs):
     """
     Flatten a nested  sequence. A sequence could be a nested list of lists
     or tuples or a combination of both
 
+    :param is_leaf: Predicate. Predicate to  determine whether an item
+                    in the iterable `xs` is a leaf node or not.
     :param xs: Iterable. Nested lists or tuples
-    :param depth: int or None. Recursion depth.
     :return: list.
     """
 
-    def _flatten(x, d):
-        for item in x:
-            if isinstance(
-                    item, Iterable) and not isinstance(
-                    item, basestring) and (
-                    d is None or d >= 1):
-                for i in flatten(item, d - 1 if d else None):
+    def _flatten_until(items):
+        for item in items:
+            if isinstance(Iterable, item) and not is_leaf(item):
+                for i in _flatten_until(item):
                     yield i
             else:
                 yield item
 
-    return list(
-        _flatten(
-            xs,
-            depth)) if (
-        isinstance(
-            xs,
-            Iterable) and not isinstance(
-            xs,
-            basestring)) else xs
+    return list(_flatten_until(xs)) if isinstance(Iterable, xs) and not is_leaf(xs) else xs
+
+flatten = flatten_until(isinstance(basestring))

--- a/pyramda/iterable/flatten_test.py
+++ b/pyramda/iterable/flatten_test.py
@@ -12,19 +12,19 @@ def test_curry_flattens_all_nested_lists():
 
 
 def test_flatten_returns_non_iterable_as_is():
-    assert flatten(1) == 1
+    assert flatten(1) == [1]
 
 
 def test_curry_flatten_returns_non_iterable_as_is():
-    assert flatten()(1) == 1
+    assert flatten()(1) == [1]
 
 
 def test_flatten_does_not_split_string_into_a_list_of_characters():
-    assert flatten('Hello World') == 'Hello World'
+    assert flatten('Hello World') == ['Hello World']
 
 
 def test_curry_flatten_does_not_split_string_into_a_list_of_characters():
-    assert flatten()('Hello World') == 'Hello World'
+    assert flatten()('Hello World') == ['Hello World']
 
 
 def test_flatten_does_not_get_stuck_in_infinite_recursion_with_strings():

--- a/pyramda/iterable/flatten_test.py
+++ b/pyramda/iterable/flatten_test.py
@@ -2,47 +2,41 @@ from .flatten import flatten
 
 
 def test_flattens_all_nested_lists():
-    assert flatten([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]], depth=None) == [
+    assert flatten([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]]) == [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
 
 def test_curry_flattens_all_nested_lists():
-    assert flatten()([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]])(
-        depth=None) == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-
-
-def test_flatten_descends_no_more_than_1_level_deep():
-    assert flatten([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]], depth=1) == [
-        1, 2, 3, 4, 5, 6, [7, 8, [9, [10, 11], 12]]]
-
-
-def test_curry_flatten_descends_no_more_than_1_level_deep():
-    assert flatten()([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]])(
-        depth=1) == [1, 2, 3, 4, 5, 6, [7, 8, [9, [10, 11], 12]]]
+    assert flatten()([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]]) == [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
 
 def test_flatten_returns_non_iterable_as_is():
-    assert flatten(1, depth=None) == 1
+    assert flatten(1) == 1
 
 
 def test_curry_flatten_returns_non_iterable_as_is():
-    assert flatten()(1)(depth=None) == 1
+    assert flatten()(1) == 1
 
 
 def test_flatten_does_not_split_string_into_a_list_of_characters():
-    assert flatten('Hello World', depth=None) == 'Hello World'
+    assert flatten('Hello World') == 'Hello World'
 
 
 def test_curry_flatten_does_not_split_string_into_a_list_of_characters():
-    assert flatten()('Hello World', depth=None) == 'Hello World'
+    assert flatten()('Hello World') == 'Hello World'
 
 
 def test_flatten_does_not_get_stuck_in_infinite_recursion_with_strings():
     assert flatten(
-        [1, 2, ['Hello', 'World'], 5, [6, [7, 8, [9, [10, 11], 12]]]],
-        depth=None) == [1, 2, 'Hello', 'World', 5, 6, 7, 8, 9, 10, 11, 12]
+        [1, 2, ['Hello', 'World'], 5, [6, [7, 8, [9, [10, 11], 12]]]]) == [1, 2, 'Hello', 'World',
+                                                                           5, 6, 7, 8, 9, 10, 11, 12
+                                                                           ]
 
 
 def test_curry_flatten_does_not_get_stuck_in_infinite_recursion_with_strings():
-    assert flatten()([1, 2, ['Hello', 'World'], 5, [6, [7, 8, [9, [10, 11], 12]]]])(
-        depth=None) == [1, 2, 'Hello', 'World', 5, 6, 7, 8, 9, 10, 11, 12]
+    assert flatten()(
+        [1, 2, ['Hello', 'World'], 5,
+         [6, [7, 8, [9, [10, 11], 12]]]]) == [1, 2, 'Hello', 'World',
+                                              5, 6, 7, 8, 9, 10, 11, 12
+                                              ]


### PR DESCRIPTION
- Remove depth from the  initial implementation
- Use a predicate to determine whether an item should be considered a leaf node or not
